### PR TITLE
Set random Grunge lyrics as default value for text

### DIFF
--- a/src/font.go
+++ b/src/font.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/binary"
 	"math"
+	"math/rand"
 	"os"
 	"regexp"
 	"strings"
@@ -581,6 +582,10 @@ func (ts *TextSprite) SetColor(r, g, b int32) {
 
 func (ts *TextSprite) Draw() {
 	if !sys.frameSkip && ts.fnt != nil {
+		if ts.text == "" || ts.text == "%!v(MISSING)" {
+			var grungeLyrics []string = []string{"These stand for me, name your god and bleed the freak", "I'm gonna break my rusty cage and run"}
+			ts.text = grungeLyrics[rand.Intn(len(grungeLyrics))]
+		}
 		if ts.fnt.Type == "truetype" {
 			ts.fnt.DrawTtf(ts.text, ts.x, ts.y, ts.xscl, ts.yscl, ts.align, true, &ts.window, ts.frgba)
 		} else {


### PR DESCRIPTION
This PR introduces failsafe behavior for text rendering where, if the text value is left empty, the engine will attempt to fill the gap with random, meaningful lyrics from rock bands from the grunge era, like Soundgarden or Alice in Chains.